### PR TITLE
fix: ensure non-null credentials for publishing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,8 +89,8 @@ publishing {
             name = "MavenCentral"
             url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
             credentials {
-                username = project.findProperty("ossrhUsername") as String? ?: System.getenv("OSSRH_USERNAME")
-                password = project.findProperty("ossrhPassword") as String? ?: System.getenv("OSSRH_PASSWORD")
+                username = project.findProperty("ossrhUsername") as String? ?: System.getenv("OSSRH_USERNAME")!!
+                password = project.findProperty("ossrhPassword") as String? ?: System.getenv("OSSRH_PASSWORD")!!
             }
         }
     }


### PR DESCRIPTION
Update the publishing credentials in build.gradle.kts to use 
non-null assertions for the username and password. This change 
ensures that the application fails fast if the required 
environment variables are not set, improving error handling 
during the publishing process.